### PR TITLE
Support multi-module Maven projects + version update

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ jobs:
           java-version: 17
 ```
 
+### Multi-Module Maven Projects
+
+If you have a multi-module Maven project you can specify the main module containing the main class using the parameter
+`module` and the main class using the parameter `main-class`.
+
 ## License
 
 The Dockerfile and associated scripts and documentation in this project are released under the [GPL-3.0 License](https://github.com/MathieuSoysal/jib-container-publish.yml/blob/main/LICENSE).

--- a/action.yaml
+++ b/action.yaml
@@ -68,7 +68,7 @@ runs:
           MAIN_CLASS_ARGS="-Djib.container.mainClass=${{ inputs.main-class }}"
         fi
 
-        mvn package com.google.cloud.tools:jib-maven-plugin:3.2.0:build \
+        mvn package com.google.cloud.tools:jib-maven-plugin:3.2.1:build \
         -Djib.to.image=${{ inputs.REGISTRY }}/${{ steps.downcase.outputs.lowercase }}:${{ inputs.tag-name }} \
         -Djib.to.auth.username=${{ inputs.USERNAME }} \
         -Djib.to.auth.password=${{ inputs.PASSWORD }} $MULTI_MODULE_ARGS $MAIN_CLASS_ARGS

--- a/action.yaml
+++ b/action.yaml
@@ -34,6 +34,14 @@ inputs:
     description: "Java version to use"
     required: true
     default: "17"
+  # Maven module
+  module:
+    description: "Maven project to build image of (in a multi module project)"
+    required: false
+  # Main class
+  main-class:
+    description: "Main class used as entry point"
+    required: false
 
 runs:
   using: "composite"
@@ -50,10 +58,18 @@ runs:
         distribution: "adopt"
         java-version: ${{ inputs.java-version }}
 
-    - name: Buil JIB container and publish to GitHub Packages
+    - name: Build JIB container and publish to GitHub Packages
       run: |
-        mvn compile com.google.cloud.tools:jib-maven-plugin:3.2.0:build \
+        if [ ! -z "${{ inputs.module }}" ]; then
+          MULTI_MODULE_ARGS="-am -pl ${{ inputs.module }}"
+        fi
+
+        if [ ! -z "${{ inputs.main-class }}" ]; then
+          MAIN_CLASS_ARGS="-Djib.container.mainClass=${{ inputs.main-class }}"
+        fi
+
+        mvn package com.google.cloud.tools:jib-maven-plugin:3.2.0:build \
         -Djib.to.image=${{ inputs.REGISTRY }}/${{ steps.downcase.outputs.lowercase }}:${{ inputs.tag-name }} \
         -Djib.to.auth.username=${{ inputs.USERNAME }} \
-        -Djib.to.auth.password=${{ inputs.PASSWORD }}
+        -Djib.to.auth.password=${{ inputs.PASSWORD }} $MULTI_MODULE_ARGS $MAIN_CLASS_ARGS
       shell: bash


### PR DESCRIPTION
It is now possible to build multi-module Maven projects by specifying the "main" Module that contains the main class.